### PR TITLE
fix(server): add "type": "module" to aws workspace package.json

### DIFF
--- a/server/deployments/aws/package.json
+++ b/server/deployments/aws/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "server": "file:../../",
     "@aws-sdk/client-lambda": "^3.1030.0",


### PR DESCRIPTION
Building the server for AWS Lambda deployment fails. The `handler` export is not exposed which results in the lambda failing to start up.

I found the issue: 
The root `server/package.json` has "type": "module", but v3.4.0 added `server/deployments/aws/package.json` without it. 
When `ncc` builds `deployments/aws/lambda-handler.ts`, it walks up the directory tree looking for a `package.json` with "type":   "module" to decide whether to output ESM or CJS. 
It hits the new workspace `package.json` first, sees no type field, and generates CJS output instead of ESM.  

The handler uses top-level await, which is ESM-only. In CJS mode, the async initialization never completes before Lambda tries to access the handler, so it's undefined.

I have not checked out the other deployment types to see if they also have similar issues, as I can only deploy to AWS Lambdas